### PR TITLE
Correções no exemplo de inserção e atualização de empresa

### DIFF
--- a/examples/empresa/nf-e/inserirAtualizar.php
+++ b/examples/empresa/nf-e/inserirAtualizar.php
@@ -32,7 +32,7 @@
 				'bairro' => 'Savassi',
 				'cep' => '32323111'
 			),
-			'emissaoNFeProduto' => {
+			'emissaoNFeProduto' => [
 				'ambienteProducao' => array(
 					'sequencialNFe' => 1,
 					'serieNFe' => '2'
@@ -41,7 +41,7 @@
 					'sequencialNFe' => 1,
 					'serieNFe' => '2'
 				)
-			}
+			]
 		);
 	
 		$result = eNotasGW::$EmpresaApi->inserirAtualizar($dadosEmpresa);

--- a/examples/empresa/nf-e/inserirAtualizar.php
+++ b/examples/empresa/nf-e/inserirAtualizar.php
@@ -1,7 +1,7 @@
 <?php
 	header('Content-Type: text/html; charset=utf-8');
 	
-	require('../src/eNotasGW.php');
+	require('../../../src/eNotasGW.php');
 	
 	use eNotasGW\Api\Exceptions as Exceptions;
 	use eNotasGW\Api\fileParameter as fileParameter;


### PR DESCRIPTION
Para que o exemplo funcionasse foi preciso fazer as seguintes correções:

- Correção em um array que foi definido utilizando chaves

- Voltar mais dois diretórios no require para a classe eNotasGW